### PR TITLE
Remove markdown dependency

### DIFF
--- a/lib/ex_minimatch.ex
+++ b/lib/ex_minimatch.ex
@@ -137,9 +137,11 @@ defmodule ExMinimatch do
   end
 
   @doc ~S"""
-  Returns true when file matches the compiled %ExMinimatcher{} struct.
+  Returns true when file matches the glob. The glob can either be a
+  compiled %ExMinimatcher{} struct, or, for convenience, a string
+  that is being compiled on the fly.
 
-  This is intended to be used with `compile`
+  For possible glob patterns and available options, please refer to moduledoc.
 
   ## Examples
 
@@ -152,34 +154,24 @@ defmodule ExMinimatch do
       iex> ["me.jpg", "images/me.png", "images/you.svg"] |> filter(compile("**/*.{png,jpg}"))
       ["me.jpg", "images/me.png"]
 
-  """
-  def match(%ExMinimatcher{pattern: pattern}, file) when pattern == [] and file == "", do: true
-  def match(%ExMinimatcher{pattern: pattern}, _file) when pattern == [], do: false
-  def match(%ExMinimatcher{} = matcher, file), do: ExMinimatch.Matcher.match_file(file, matcher)
-
-  @doc """
-  Return true if the file matches the glob. This is a convenience function that
-  is literally `glob |> compile(options) |> match(file)`
-
-  Use this for one off matching, as the glob is recompiled every time this is
-  called.
-
-  For possible glob patterns and available options, please refer to moduledoc.
-
-  ## Examples
-
       iex> match("**/*.png", "qwer.png")
       true
-
       iex> match("**/*.png", "qwer/qwer.png")
       true
 
   """
+  def match(%ExMinimatcher{pattern: pattern}, file) when pattern == [] and file == "", do: true
+  def match(%ExMinimatcher{pattern: pattern}, _file) when pattern == [], do: false
+  def match(%ExMinimatcher{} = matcher, file), do: ExMinimatch.Matcher.match_file(file, matcher)
   def match(glob, file) when is_binary(glob), do: match(glob, file, %{})
   def match(glob, file, options) when is_binary(glob), do: glob |> compile(options) |> match(file)
 
   @doc """
-  Returns a list of files filtered by the compiled %ExMinimatcher{} struct.
+  Returns a list of files filtered by the glob. The glob can either be a
+  compiled %ExMinimatcher{} struct, or, for convenience, a string
+  that is being compiled on the fly.
+
+  For possible glob patterns and available options, please refer to moduledoc.
 
   Note the collection argument comes first, different from `match`. This is
   more suitable for piping collections.
@@ -189,17 +181,6 @@ defmodule ExMinimatch do
       iex> ["me.jpg", "images/me.png", "images/you.svg"] |> filter(compile("**/*.{png,jpg}"))
       ["me.jpg", "images/me.png"]
 
-  """
-  def filter(files, %ExMinimatcher{} = matcher), do: files |> Enum.filter(&match(matcher, &1))
-
-  @doc """
-  return a list of files that match the given pattern. This is a convenience
-  function
-
-  For possible glob patterns and available options, please refer to moduledoc.
-
-  ## Examples
-
       iex> filter(["qwer.png", "asdf/qwer.png"], "**/*.png")
       ["qwer.png", "asdf/qwer.png"]
 
@@ -207,6 +188,8 @@ defmodule ExMinimatch do
       ["qwer/pic1a.png", "qwer/asdf/pic2a.png"]
 
   """
+
+  def filter(files, %ExMinimatcher{} = matcher), do: files |> Enum.filter(&match(matcher, &1))
   def filter(files, pattern) when is_binary(pattern), do: filter(files, pattern, %{})
   def filter(files, pattern, options) when is_binary(pattern), do: files |> filter(compile(pattern, options))
 

--- a/lib/ex_minimatch.ex
+++ b/lib/ex_minimatch.ex
@@ -11,7 +11,7 @@ defmodule ExMinimatch do
   Quick examples:
 
       iex> import ExMinimatch
-      nil
+      ExMinimatch
 
       iex> match("**/*{1..2}{a,b}.{png,jpg}", "asdf/pic2a.jpg")
       true

--- a/lib/ex_minimatch.ex
+++ b/lib/ex_minimatch.ex
@@ -131,7 +131,7 @@ defmodule ExMinimatch do
       nocomment: false,
       nobrace: false,
       log: nil
-    } |> Dict.merge(options)
+    } |> Map.merge(options)
 
     ExMinimatch.Compiler.compile_matcher(glob, options)
   end

--- a/lib/ex_minimatch/compiler.ex
+++ b/lib/ex_minimatch/compiler.ex
@@ -160,7 +160,9 @@ defmodule ExMinimatch.Compiler do
     |> continue
   end
 
-  def parse(%{c: c} = state) when c == "/", do: state |> merge %{failed: true}
+  def parse(%{c: c} = state) when c == "/" do
+    state |> merge(%{failed: true})
+  end
 
   def parse(%{c: c} = state) when c == "\\" do
     state

--- a/lib/ex_minimatch/compiler.ex
+++ b/lib/ex_minimatch/compiler.ex
@@ -6,8 +6,6 @@ defmodule ExMinimatch.Compiler do
   @qmark ExMinimatcher.qmark
   @globstar ExMinimatcher.globstar
   @star ExMinimatcher.star
-  @two_star_dot ExMinimatcher.two_star_dot
-  @two_star_no_dot ExMinimatcher.two_star_no_dot
   @re_specials ExMinimatcher.re_specials
   @slash_split ExMinimatcher.slash_split
 

--- a/lib/ex_minimatch/compiler.ex
+++ b/lib/ex_minimatch/compiler.ex
@@ -1,5 +1,5 @@
 defmodule ExMinimatch.Compiler do
-  import Dict, only: [merge: 2]
+  import Map, only: [merge: 2]
   import ExBraceExpansion
   import ExMinimatch.Helper
 

--- a/lib/ex_minimatch/matcher.ex
+++ b/lib/ex_minimatch/matcher.ex
@@ -2,12 +2,7 @@ defmodule ExMinimatch.Matcher do
   import Dict, only: [merge: 2]
   import ExMinimatch.Helper
 
-  @qmark ExMinimatcher.qmark
   @globstar ExMinimatcher.globstar
-  @star ExMinimatcher.star
-  @two_star_dot ExMinimatcher.two_star_dot
-  @two_star_no_dot ExMinimatcher.two_star_no_dot
-  @re_specials ExMinimatcher.re_specials
   @slash_split ExMinimatcher.slash_split
 
   def match_file(file, %ExMinimatcher{pattern: regex_parts_set, negate: negate, options: options}) do

--- a/lib/ex_minimatcher.ex
+++ b/lib/ex_minimatcher.ex
@@ -24,17 +24,6 @@ defmodule ExMinimatcher do
   @star "#{@qmark}*?"
   def star, do: @star
 
-  # ** when dots are allowed.  Anything goes, except .. and .
-  # not (^ or / followed by one or two dots followed by $ or /),
-  # followed by anything, any number of times.
-  @two_star_dot "(?:(?!(?:\\\/|^)(?:\\.{1,2})($|\\\/)).)*?"
-  def two_star_dot, do: @two_star_dot
-
-  # not a ^ or / followed by a dot,
-  # followed by anything, any number of times.
-  @two_star_no_dot "(?:(?!(?:\\\/|^)\\.).)*?"
-  def two_star_no_dot, do: @two_star_no_dot
-
   # characters that need to be escaped in RegExp.
   @re_specials [ "(", ")", ".", "*", "{", "}", "+", "?", "[", "]", "^", "$", "\\", "!" ]
   def re_specials, do: @re_specials

--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule ExMinimatch.Mixfile do
     [app: :ex_minimatch,
      version: "0.0.1",
      elixir: "~> 1.0",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application
@@ -29,8 +29,7 @@ defmodule ExMinimatch.Mixfile do
   defp deps do
     [
       {:ex_brace_expansion, "~> 0.0.1"},
-      {:ex_doc, "~> 0.7", only: :dev},
-      {:markdown, github: "devinus/markdown"}
+      {:ex_doc, "~> 0.7", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"ex_brace_expansion": {:hex, :ex_brace_expansion, "0.0.1"},
-  "ex_doc": {:hex, :ex_doc, "0.7.2"},
-  "hoedown": {:git, "git://github.com/hoedown/hoedown.git", "2a4cf17c70e6572ed42cdca3ea7ca3e768ed17be", []},
-  "markdown": {:git, "git://github.com/devinus/markdown.git", "cd0df79b6f1cc374499d47f6ba6aaab5096f874f", []}}
+%{
+  "ex_brace_expansion": {:hex, :ex_brace_expansion, "0.0.1", "4cb3b7aff8677f67c72e527f3bb35e4e5cf8e914540d67c967e4ab385b12159f", [:mix], [], "hexpm", "3062ed7a088f925f93360bd10694b4bd6f350617fa42681e460050db2ceff61a"},
+  "ex_doc": {:hex, :ex_doc, "0.7.2", "c24bd9efdace906c23c943280a3d29c15e649e4c0eeca92f6ee35723f44691a7", [:mix], [], "hexpm", "8bb0b9272b4b427a0f8f915b85a82a3296be8c3a3814891b1c9d090839b5d396"},
+  "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
+  "markdown": {:git, "https://github.com/devinus/markdown.git", "d065dbcc4e242a85ca2516fdadd0082712871fd8", []},
+}


### PR DESCRIPTION
This PR removes the markdown dependency, which is not necessary here.

It also cleans up a few things, in order for a clean compilation of the module.